### PR TITLE
Support non-functions in spriteTexts

### DIFF
--- a/src/templates/templates.js
+++ b/src/templates/templates.js
@@ -23,14 +23,14 @@ export const TRUST_INCREASE_TEMPLATES = {
 };
 
 export const TREAT_GIFT_TEMPLATES = [
-  (sprite, treats) => `${Kimberly(sprite)} twirls around as ${they(sprite)}
-    ${_v('give')(sprite)} you ${treats} ${_n('treat')(treats)}.`,
-  (sprite, treats) => `${Kimberly(sprite)} ${purr(sprite)}s gently as
-    ${they(sprite)} ${_v('reveal')(sprite)} a gift: ${treats}
+  (sprite, treats) => spriteText(sprite)`${Kimberly} twirls around as ${they}
+    ${_v('give')} you ${treats} ${_n('treat')(treats)}.`,
+  (sprite, treats) => spriteText(sprite)`${Kimberly} ${purr}s gently as
+    ${they} ${_v('reveal')} a gift: ${treats}
     ${_n('treat')(treats)}.`,
-  (sprite, treats) => `${Kimberly(sprite)} excitedly hands you
+  (sprite, treats) => spriteText(sprite)`${Kimberly} excitedly hands you
     ${treats} ${_n('treat')(treats)}.`,
-  (sprite, treats) => `${Kimberly(sprite)} celebrates your friendship by
+  (sprite, treats) => spriteText(sprite)`${Kimberly} celebrates your friendship by
     giving you ${treats} ${_n('treat')(treats)}.`,
 ];
 

--- a/src/textGenerators/helpers.js
+++ b/src/textGenerators/helpers.js
@@ -15,8 +15,10 @@ export const spriteText = sprite => (strings, ...keys) => {
   let result = '';
   for (let i = 0; i < strings.length; i += 1) {
     result = result.concat(strings[i]);
-    if (i < keys.length) {
+    if (i < keys.length && typeof keys[i] === 'function') {
       result = result.concat(keys[i](sprite));
+    } else if (i < keys.length) {
+      result = result.concat(keys[i]);
     }
   }
   return result;


### PR DESCRIPTION
Pretty straightforward, this makes the spriteText tag only pass sprite to functions. This should help support using other functions in the templates.