### PR TITLE
 Event text refactor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ import { TRUST_INCREASE_TEMPLATES,
 
 import { addWildSprite, befriendWildSprite, setActiveSprite, interactWithSprite,
   clearInteractions } from './reducers/spriteReducer';
-import { advanceDay, addTreat } from './reducers/gameReducer';
+import { advanceDay, addTreat, setEventText } from './reducers/gameReducer';
 
 
 const generateSprite = () => {
@@ -108,6 +108,10 @@ class App extends Component {
     this.props.interactWithSprite(sprite.name, interactionType, treats,
       lastPlayedTimestamp);
 
+    this.props.setEventText(
+      this.generateEventText({ type: interactionType, treatIncrease: treats })
+    );
+
     if ((sprite.trust + trustIncrease > TRUST_LEVELS.bonded)
         && !this.props.activeSpriteId) {
       this.befriendWildSprite();
@@ -128,16 +132,16 @@ class App extends Component {
     return randomChoice(templates.bonded)(sprite);
   }
 
-  generateEventText() {
+  generateEventText(interaction) {
     const sprite = this.currentSprite();
-    const { lastInteraction, trust } = sprite;
-    const { type, treatIncrease } = lastInteraction || {};
-    const lastInteractionType = INTERACTION_TYPES[type];
-    const trustIncrease = lastInteraction ? lastInteractionType.trustIncrease : 0;
+    const { trust } = sprite;
+    const { type, treatIncrease } = interaction;
+    const interactionType = INTERACTION_TYPES[type];
+    const trustIncrease = interaction ? interactionType.trustIncrease : 0;
     const oldTrust = trust - trustIncrease;
 
-    if (lastInteractionType) {
-      let eventText = this.chooseTextByTrust(lastInteractionType.templates, trust);
+    if (interactionType) {
+      let eventText = this.chooseTextByTrust(interactionType.templates, trust);
 
       if (trust >= TRUST_LEVELS.bonded && oldTrust < TRUST_LEVELS.bonded) {
         eventText = `${eventText} ${randomChoice(TRUST_INCREASE_TEMPLATES.bonded)(sprite)}`;
@@ -162,8 +166,6 @@ class App extends Component {
     const { mySpriteIds, activeSpriteId, treatCount } = this.props;
     const now = this.currentTime();
     const isWildSprite = !activeSpriteId;
-
-    const eventText = this.generateEventText();
 
     const interactText = interactionType => (sprite
       && INTERACTION_TYPES[interactionType].buttonTextTemplate(sprite));
@@ -216,7 +218,7 @@ class App extends Component {
               {`Trust level: ${sprite.trust},
               Treat count: ${treatCount}`}
             </p>
-            <p className="event-text">{eventText}</p>
+            <p className="event-text">{this.props.eventText}</p>
             {
               Object.keys(INTERACTION_TYPES).map(interaction => (
                 <button
@@ -253,6 +255,7 @@ const mapStateToProps = state => ({
 
   dayOffset: state.game.dayOffset,
   treatCount: state.game.treatCount,
+  eventText: state.game.eventText,
 });
 
 const mapDispatchToProps = {
@@ -263,6 +266,7 @@ const mapDispatchToProps = {
   clearInteractions,
   advanceDay,
   addTreat,
+  setEventText,
 };
 
 App.propTypes = {
@@ -273,6 +277,7 @@ App.propTypes = {
   clearInteractions: PropTypes.func.isRequired,
   advanceDay: PropTypes.func.isRequired,
   addTreat: PropTypes.func.isRequired,
+  setEventText: PropTypes.func.isRequired,
 
   spritesById: PropTypes.object.isRequired,
   mySpriteIds: PropTypes.array.isRequired,
@@ -283,6 +288,7 @@ App.propTypes = {
 
   dayOffset: PropTypes.number.isRequired,
   treatCount: PropTypes.number.isRequired,
+  eventText: PropTypes.string.isRequired,
 };
 
 export default connect(

--- a/src/App.js
+++ b/src/App.js
@@ -27,7 +27,8 @@ const generateSprite = () => {
     name: capitalizeFirst(soulName()),
     species,
     color,
-    trust: 0,
+    trust: -5,
+    distance: 5,
     grammar: randomChoice([SHE_PRONOUNS, HE_PRONOUNS,
       THEY_PRONOUNS]),
   };
@@ -152,7 +153,7 @@ class App extends Component {
 
       return eventText;
     }
-    return null;
+    return `You spot a wild ${sprite.species} in the distance.`;
   }
 
   render() {

--- a/src/gameData/spriteInteractions.js
+++ b/src/gameData/spriteInteractions.js
@@ -2,6 +2,7 @@
 import { PET_TEMPLATES, WATER_TEMPLATES, GROOM_TEMPLATES, TREAT_TEMPLATES, SING_TEMPLATES } from '../templates/templates';
 
 export const TRUST_LEVELS = {
+  neutral: 0,
   curious: 2,
   friendly: 5,
   bonded: 8,

--- a/src/reducers/gameReducer.js
+++ b/src/reducers/gameReducer.js
@@ -3,10 +3,12 @@ import { INTERACT_WITH_SPRITE } from './spriteReducer';
 const initialState = {
   dayOffset: 0,
   treatCount: 20,
+  eventText: '',
 };
 
 export const ADVANCE_DAY = 'ADVANCE_DAY';
 export const ADD_TREAT = 'ADD_TREAT';
+export const SET_EVENT_TEXT = 'SET_EVENT_TEXT';
 
 export function advanceDay() {
   return { type: ADVANCE_DAY };
@@ -15,6 +17,11 @@ export function advanceDay() {
 export function addTreat(treatIncreaseArg) {
   const treatIncrease = treatIncreaseArg || 1;
   return { type: ADD_TREAT, treatIncrease };
+}
+
+export function setEventText(eventTextArg) {
+  const eventText = eventTextArg || '';
+  return { type: SET_EVENT_TEXT, eventText };
 }
 
 export default function gameReducer(state = initialState, action) {
@@ -26,6 +33,8 @@ export default function gameReducer(state = initialState, action) {
       return Object.assign({}, state, {
         treatCount: state.treatCount + action.treatIncrease,
       });
+    case SET_EVENT_TEXT:
+      return Object.assign({}, state, { eventText: action.eventText });
     default:
       return state;
   }

--- a/src/reducers/spriteReducer.js
+++ b/src/reducers/spriteReducer.js
@@ -73,10 +73,6 @@ export default function spriteReducer(state = initialState, action) {
         spritesById: Object.assign({}, state.spritesById, {
           [id]: Object.assign({}, state.spritesById[id], {
             trust: state.spritesById[id].trust + trust,
-            lastInteraction: {
-              type: interaction,
-              treatIncrease: action.treatIncrease,
-            },
           }),
         }),
         interactionCounts: Object.assign({}, interactionCounts, {

--- a/src/templates/templates.js
+++ b/src/templates/templates.js
@@ -22,6 +22,24 @@ export const TRUST_INCREASE_TEMPLATES = {
   ],
 };
 
+export const APPROACH_TEMPLATES = {
+  comfortable: [
+    sprite => spriteText(sprite)`${They} ${_v('seem')} comfortable with your presence.`,
+  ],
+  anxious: [
+    sprite => spriteText(sprite)`${They} ${_v('seem')} anxious. You might be moving too quickly.`,
+  ],
+};
+
+export const WAIT_TEMPLATES = {
+  comfortable: [
+    sprite => spriteText(sprite)`${They} ${_v('look')} bored.`,
+  ],
+  anxious: [
+    sprite => spriteText(sprite)`You give ${them} a little space. They look a little calmer.`,
+  ],
+};
+
 export const TREAT_GIFT_TEMPLATES = [
   (sprite, treats) => spriteText(sprite)`${Kimberly} twirls around as ${they}
     ${_v('give')} you ${treats} ${_n('treat')(treats)}.`,


### PR DESCRIPTION
Changed event texts to be stored in the game state instead of retroactively calculating them from the sprite state.